### PR TITLE
refactor: Reduce public interface

### DIFF
--- a/Engine/Source/Editor/EditorWindow.cpp
+++ b/Engine/Source/Editor/EditorWindow.cpp
@@ -5,8 +5,8 @@
 unsigned int width, height;
 void Editor::showMainWindow(VulkanRenderer& renderer)
 {
-    width = renderer.swapChainObj.actualExtent.width;
-    height = renderer.swapChainObj.actualExtent.height;
+    width = renderer.GetWidth();
+    height = renderer.GetHeight();
     setupDockSpace();
     ImGui::ShowDemoWindow();
     Viewport::ShowGameViewport(renderer);

--- a/Engine/Source/Editor/Imgui_layer.cpp
+++ b/Engine/Source/Editor/Imgui_layer.cpp
@@ -34,7 +34,7 @@ void imgui_layer::InitImguiLayer(VulkanRenderer& renderer, bool showWindow /*= t
 		pool_info.pPoolSizes = poolSizes;
 
 		VkDescriptorPool imguiPool;
-		VK_CHECK(vkCreateDescriptorPool(renderer.device, &pool_info, nullptr, &imguiPool));
+		VK_CHECK(vkCreateDescriptorPool(renderer.GetDevice(), &pool_info, nullptr, &imguiPool));
 
 
 		// 2: initialize imgui library
@@ -93,15 +93,15 @@ void imgui_layer::InitImguiLayer(VulkanRenderer& renderer, bool showWindow /*= t
 
 		//this initializes imgui for Vulkan
 		ImGui_ImplVulkan_InitInfo init_info = {};
-		init_info.Instance = renderer.instance;
-		init_info.PhysicalDevice = renderer.chosenGPU;
-		init_info.Device = renderer.device;
-		init_info.Queue = renderer.graphicsQueue;
+		init_info.Instance = renderer.GetInstance();
+		init_info.PhysicalDevice = renderer.GetPhysicalDevice();
+		init_info.Device = renderer.GetDevice();
+		init_info.Queue = renderer.GetGraphicsQueue();
 		init_info.DescriptorPool = imguiPool;
 		init_info.MinImageCount = 3;
 		init_info.ImageCount = 3;
 
-		ImGui_ImplVulkan_Init(&init_info, renderer.renderPass);
+		ImGui_ImplVulkan_Init(&init_info, renderer.GetRenderPass());
 
 		//execute a gpu command to upload imgui font textures
 		renderer.ImmediateSubmit([&](VkCommandBuffer cmd) {
@@ -112,10 +112,10 @@ void imgui_layer::InitImguiLayer(VulkanRenderer& renderer, bool showWindow /*= t
 		ImGui_ImplVulkan_DestroyFontUploadObjects();
 
 		//add the destroy the imgui created structures
-		renderer.mainDeletionQueue.PushFunction([=]() {
+		renderer.EnqueueCleanup([=]() {
 			ImGui_ImplVulkan_Shutdown();
-			vkDestroyDescriptorPool(renderer.device, imguiPool, nullptr);
-			});
+			vkDestroyDescriptorPool(init_info.Device, imguiPool, nullptr);
+        });
 	}
 }
 

--- a/Engine/Source/RendererCore/Include/renderer_core.h
+++ b/Engine/Source/RendererCore/Include/renderer_core.h
@@ -11,13 +11,15 @@ namespace RendererCore
     void RendererEvents();
     void CleanupRenderer();
 
+    void InitScene();
     void LoadMeshes();
+    void LoadTextures();
+    void LoadMaterials();
+    void LoadRenderables();
+
     void CreateMaterial(const std::string& name);
     Material* GetMaterial(const std::string& name);
     Mesh* GetMesh(const std::string& name);
-
-    void InitScene();
-
 
     WindowHandler GetWindowHandler();
 

--- a/Engine/Source/RendererCore/renderer_core.cpp
+++ b/Engine/Source/RendererCore/renderer_core.cpp
@@ -13,12 +13,6 @@ void RendererCore::InitRenderer()
 {
     windowHandler.CreateWindow(1920, 1080);
     vkRenderer.Init(windowHandler);
-	CreateMaterial("texturedmesh2");
-	CreateMaterial("texturedmesh");
-	CreateMaterial("texturedmesh3");
-	CreateMaterial("DamagedHelmetMat");
-	CreateMaterial("BarrelMat");
-	vkRenderer.InitScene();
     InitScene();
 }
 
@@ -29,7 +23,7 @@ void RendererCore::UpdateRenderer()
     deltaTime = elapsed_seconds.count() * 1000.f;
     start = std::chrono::system_clock::now();
    
-    vkRenderer.camera.UpdateCamera(deltaTime);
+    vkRenderer.GetCamera().UpdateCamera(deltaTime);
     vkRenderer.BeginDraw();
 
     vkRenderer.DrawObjects(renderables);
@@ -40,7 +34,7 @@ void RendererCore::UpdateRenderer()
 
 void RendererCore::RendererEvents()
 {
-    vkRenderer.camera.ProcessInputEvent(windowHandler);
+    vkRenderer.GetCamera().ProcessInputEvent(windowHandler);
     
 }
 
@@ -76,6 +70,15 @@ WindowHandler RendererCore::GetWindowHandler()
 	return windowHandler;
 }
 
+
+void RendererCore::InitScene()
+{
+    LoadMeshes();
+	LoadMaterials();
+	LoadTextures();
+	// Must be called after the load functions above
+	LoadRenderables();
+}
 
 void RendererCore::LoadMeshes()
 {
@@ -200,9 +203,15 @@ void RendererCore::LoadMeshes()
 	meshes["Barrel"] = Barrel;
 }
 
-void RendererCore::InitScene()
+void RendererCore::LoadMaterials()
 {
-    LoadMeshes();
+	CreateMaterial("texturedmesh2");
+	CreateMaterial("texturedmesh");
+	CreateMaterial("texturedmesh3");
+	CreateMaterial("DamagedHelmetMat");
+	CreateMaterial("BarrelMat");
+
+	// TODO: Configure through one function call
 	GetMaterial("texturedmesh")->albedo = glm::vec4(1.0f);
 	GetMaterial("texturedmesh")->metallic = 0.5f;
 	GetMaterial("texturedmesh")->roughness = 0.5f;
@@ -237,7 +246,44 @@ void RendererCore::InitScene()
 	GetMaterial("BarrelMat")->ao = 1.0f;
 	GetMaterial("BarrelMat")->emissionColor = glm::vec4(1.0f, 0.3f, 0.0f, 1.0f);
 	GetMaterial("BarrelMat")->emissionPower = 8.0f;
+}
 
+void RendererCore::LoadTextures()
+{
+	//lost empire
+	vkRenderer.CreateTexture("texturedmesh", "EngineAssets/Textures/lost_empire-RGBA.png", 0);
+	//viking room
+	vkRenderer.CreateTexture("texturedmesh3", "EngineAssets/Textures/viking_room.png", 0);
+
+	//DamagedHelmet
+
+	//diffuse
+	vkRenderer.CreateTexture("DamagedHelmetMat", "EngineAssets/DamagedHelmet/Default_albedo.jpg", 0);
+	//ao
+	vkRenderer.CreateTexture("DamagedHelmetMat", "EngineAssets/DamagedHelmet/Default_AO.jpg", 1);
+	//normal
+	vkRenderer.CreateTexture("DamagedHelmetMat", "EngineAssets/DamagedHelmet/Default_normal.jpg", 2);
+
+	//emission
+	vkRenderer.CreateTexture("DamagedHelmetMat", "EngineAssets/DamagedHelmet/Default_emissive.jpg", 3);
+	//metallicRoughness
+	vkRenderer.CreateTexture("DamagedHelmetMat", "EngineAssets/DamagedHelmet/Default_metalRoughness.jpg", 4);
+
+
+	//Barrel
+	//diffuse
+	vkRenderer.CreateTexture("BarrelMat", "EngineAssets/Textures/ExplosionBarrel Diffuse.png", 0);
+	//emission
+	vkRenderer.CreateTexture("BarrelMat", "EngineAssets/Textures/ExplosionBarrel Emission.png", 3);
+	//Metallic
+	vkRenderer.CreateTexture("BarrelMat", "EngineAssets/Textures/ExplosionBarrel Metallic.png", 5);
+	//Roughness
+	vkRenderer.CreateTexture("BarrelMat", "EngineAssets/Textures/ExplosionBarrel Roughness.png", 6);
+}
+
+
+void RendererCore::LoadRenderables()
+{
 	RenderObject monkey;
 	monkey.p_mesh = GetMesh("monkey");
 	monkey.p_material = GetMaterial("texturedmesh2");

--- a/Engine/Source/Vulkan/vk_components/Include/vk_pipelinebuilder.h
+++ b/Engine/Source/Vulkan/vk_components/Include/vk_pipelinebuilder.h
@@ -36,5 +36,5 @@ namespace vkcomponent
 		VkPipelineLayout layout{ VK_NULL_HANDLE };
 	};
 
-    ShaderEffect* BuildEffect(VulkanRenderer* p_renderer, std::vector<vkcomponent::ShaderModule>& shaders, std::vector<ShaderEffect::ReflectionOverrides> overrides={});
+    ShaderEffect* BuildEffect(VkDevice& device, std::vector<vkcomponent::ShaderModule>& shaders, std::vector<ShaderEffect::ReflectionOverrides> overrides={});
 }

--- a/Engine/Source/Vulkan/vk_components/vk_pipelinebuilder.cpp
+++ b/Engine/Source/Vulkan/vk_components/vk_pipelinebuilder.cpp
@@ -83,7 +83,7 @@ namespace vkcomponent
         pipelineLayout = effect->builtLayout;
     }
 
-    ShaderEffect* BuildEffect(VulkanRenderer* p_renderer, std::vector<vkcomponent::ShaderModule>& shaders, std::vector<ShaderEffect::ReflectionOverrides> overrides/*={}*/)
+    ShaderEffect* BuildEffect(VkDevice& device, std::vector<vkcomponent::ShaderModule>& shaders, std::vector<ShaderEffect::ReflectionOverrides> overrides/*={}*/)
     {
         //textured defaultlit shader
         ShaderEffect* effect = new ShaderEffect();
@@ -95,11 +95,11 @@ namespace vkcomponent
         }
         if(overrides.size() != 0)
         {
-            effect->ReflectLayout(p_renderer->device, overrides.data(), overrides.size());
+            effect->ReflectLayout(device, overrides.data(), overrides.size());
         }
         else
         {
-            effect->ReflectLayout(p_renderer->device, nullptr, 0);
+            effect->ReflectLayout(device, nullptr, 0);
         }
         return effect; 
     }

--- a/Engine/Source/Vulkan/vk_components/vk_textures.cpp
+++ b/Engine/Source/Vulkan/vk_components/vk_textures.cpp
@@ -29,7 +29,7 @@ namespace {
         dimg_allocinfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
 
         //allocate and create the image
-        vmaCreateImage(renderer.allocator, &dimg_info, &dimg_allocinfo, &outImage->image, &outImage->allocation, nullptr);
+        vmaCreateImage(renderer.GetAllocator(), &dimg_info, &dimg_allocinfo, &outImage->image, &outImage->allocation, nullptr);
 
         //transition image to transfer-receiver	
         renderer.ImmediateSubmit([&](VkCommandBuffer cmd) {
@@ -117,16 +117,16 @@ bool vkcomponent::LoadImageFromFile(VulkanRenderer& renderer, const char* p_file
 		info.allocSize = imageSize;
 		info.bufferUsage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 		info.memoryUsage = VMA_MEMORY_USAGE_CPU_ONLY;
-		CreateBuffer(renderer.allocator, &stagingBuffer, info);
+		CreateBuffer(renderer.GetAllocator(), &stagingBuffer, info);
 	}
 
-	UploadArrayData(renderer.allocator, stagingBuffer.allocation, pixels, imageSize);
+	UploadArrayData(renderer.GetAllocator(), stagingBuffer.allocation, pixels, imageSize);
     //we no longer need the loaded data, so we can free the pixels as they are now in the staging buffer
 	stbi_image_free(pixels);
 
     UploadImage(texWidth, texHeight, image_format, renderer, stagingBuffer, outImage);
 
-	vmaDestroyBuffer(renderer.allocator, stagingBuffer.buffer, stagingBuffer.allocation);
+	vmaDestroyBuffer(renderer.GetAllocator(), stagingBuffer.buffer, stagingBuffer.allocation);
 
 	ENGINE_CORE_INFO("Texture loaded succesfully {0}", p_filename);
 
@@ -170,18 +170,18 @@ bool vkcomponent::LoadImageFromAsset(VulkanRenderer& renderer, const char* p_fil
 		info.allocSize = imageSize;
 		info.bufferUsage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 		info.memoryUsage = VMA_MEMORY_USAGE_CPU_ONLY;
-		CreateBuffer(renderer.allocator, &stagingBuffer, info);
+		CreateBuffer(renderer.GetAllocator(), &stagingBuffer, info);
 	}
 
 	// Note: vmaMapMemory allocates memory for data and vmaUnmapMemory deallocates memory
 	void* data;
-	vmaMapMemory(renderer.allocator, stagingBuffer.allocation, &data);
+	vmaMapMemory(renderer.GetAllocator(), stagingBuffer.allocation, &data);
 	assets::unpack_texture(&textureInfo, file.binaryBlob.data(), file.binaryBlob.size(), (char*)data);	
-	vmaUnmapMemory(renderer.allocator, stagingBuffer.allocation);	
+	vmaUnmapMemory(renderer.GetAllocator(), stagingBuffer.allocation);	
 
 	UploadImage(textureInfo.pixelsize[0], textureInfo.pixelsize[1], image_format, renderer, stagingBuffer, outImage);
 
-	vmaDestroyBuffer(renderer.allocator, stagingBuffer.buffer, stagingBuffer.allocation);
+	vmaDestroyBuffer(renderer.GetAllocator(), stagingBuffer.buffer, stagingBuffer.allocation);
 	
 	return true;
 }
@@ -203,13 +203,13 @@ void vkcomponent::LoadEmpty(VulkanRenderer& renderer, AllocatedImage* outImage)
 		info.allocSize = imageSize;
 		info.bufferUsage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 		info.memoryUsage = VMA_MEMORY_USAGE_CPU_ONLY;
-		CreateBuffer(renderer.allocator, &stagingBuffer, info);
+		CreateBuffer(renderer.GetAllocator(), &stagingBuffer, info);
 	}
 
     // copy pixel data to buffer
-	UploadArrayData(renderer.allocator, stagingBuffer.allocation, pixelData, 4);
+	UploadArrayData(renderer.GetAllocator(), stagingBuffer.allocation, pixelData, 4);
     UploadImage(texWidth, texHeight, image_format, renderer, stagingBuffer, outImage);
 
-	vmaDestroyBuffer(renderer.allocator, stagingBuffer.buffer, stagingBuffer.allocation);
+	vmaDestroyBuffer(renderer.GetAllocator(), stagingBuffer.buffer, stagingBuffer.allocation);
 }
 


### PR DESCRIPTION
The public interface of VulkanRenderer was reduces as much as
possible. It is also now clear that some functionality does not
belong to the renderer such as material and texture management.